### PR TITLE
Add GitHub Actions build and release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,82 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    name: Build macOS (Universal Binary)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache CMake dependencies
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: deps-macos-${{ hashFiles('CMakeLists.txt') }}
+
+      - name: Prepare plugin install dirs
+        run: mkdir -p ~/Library/Audio/Plug-Ins/VST3 ~/Library/Audio/Plug-Ins/Components
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+      - name: Build
+        run: cmake --build build --config Release -j$(sysctl -n hw.ncpu)
+
+      - name: Package
+        run: |
+          ARTIFACTS="build/ReMastered_artefacts/Release"
+          DIST="dist/ReMastered-macOS"
+          mkdir -p "$DIST"
+
+          cp -r "$ARTIFACTS/VST3/ReMastered.vst3"          "$DIST/"
+          cp -r "$ARTIFACTS/AU/ReMastered.component"        "$DIST/"
+          cp -r "$ARTIFACTS/Standalone/ReMastered.app"      "$DIST/"
+
+          cat > "$DIST/INSTALL.txt" << 'EOF'
+          ReMastered — macOS Installation
+          ================================
+          Universal Binary: Apple Silicon (M1/M2/M3/M4) + Intel
+
+          Plugins (use inside a DAW — Logic, Ableton, etc.):
+            Copy ReMastered.vst3        →  ~/Library/Audio/Plug-Ins/VST3/
+            Copy ReMastered.component   →  ~/Library/Audio/Plug-Ins/Components/
+
+          Standalone (no DAW required):
+            Double-click ReMastered.app to run directly.
+
+          ── Gatekeeper notice ──────────────────────────────────────────
+          macOS may say "unidentified developer" on first launch.
+          To allow it: System Settings → Privacy & Security → Open Anyway
+          ───────────────────────────────────────────────────────────────
+          EOF
+
+          cd dist
+          zip -r "../ReMastered-macOS-${GITHUB_REF_NAME}.zip" ReMastered-macOS
+          echo "ZIP=ReMastered-macOS-${GITHUB_REF_NAME}.zip" >> "$GITHUB_ENV"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReMastered-macOS
+          path: ${{ env.ZIP }}
+          retention-days: 30
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ZIP }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-release.yml` to automatically build and publish releases
- Builds a Universal Binary (arm64 + Intel) on macOS
- Packages VST3 + AU plugin + Standalone app + install instructions into a zip
- Publishes a GitHub Release with the zip attached when a version tag is pushed

## How to cut a release after merging
```bash
git tag v1.0.0
git push origin v1.0.0
```
The Actions workflow will run, build everything, and attach `ReMastered-macOS-v1.0.0.zip` to a GitHub Release automatically.

## Notes
- `workflow_dispatch` trigger is also included for test builds from the Actions tab without tagging
- Binaries are unsigned; the included `INSTALL.txt` guides users through the Gatekeeper "Open Anyway" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)